### PR TITLE
Fix black images for UI icons

### DIFF
--- a/react-client/src/components/App.js
+++ b/react-client/src/components/App.js
@@ -651,15 +651,15 @@ class App extends React.Component {
               {/* most of these UI icons are pre-cached in the signin route */}
               <img id="profilePic" crossOrigin="anonymous" src={self.state.profilePic} />
 
-              <img id="close" crossOrigin="anonymous" src="https://s3.amazonaws.com/vrpics/ui-icons/icon-home_512x512.png" />
-              <img id="like" crossOrigin="anonymous" src="https://s3.amazonaws.com/vrpics/ui-icons/icon-favorite_512x512.png" />
+              <img id="close" alt="home" crossOrigin="anonymous" src="http://i.imgur.com/PMgJxSU.png" />
+              <img id="like" crossOrigin="anonymous" src="http://i.imgur.com/Iz5kgoH.png" />
               <img id="liked" crossOrigin="anonymous" src="http://i.imgur.com/XTLYqU3.png" />
 
-              <img id="mic" crossOrigin="anonymous" src="https://s3.amazonaws.com/vrpics/ui-icons/icon-mic_512x512.png" />
-              <img id="micActivated" crossOrigin="anonymous" src="https://s3.amazonaws.com/vrpics/ui-icons/icon-mic-activated_512x512.png" />
+              <img id="mic" crossOrigin="anonymous" src="http://i.imgur.com/wNqlh3b.png" />
+              <img id="micActivated" crossOrigin="anonymous" src="http://i.imgur.com/p433Gsv.png" />
               <img id="info" crossOrigin="anonymous" src="http://i.imgur.com/BGRK0Vf.png" />
 
-              <img id="exit" crossOrigin="anonymous" src="https://s3.amazonaws.com/vrpics/ui-icons/icon-dashboard_512x512.png" />
+              <img id="exit" crossOrigin="anonymous" src="http://i.imgur.com/5x56Jce.png" />
               <img id="input" crossOrigin="anonymous" src="http://i.imgur.com/sELlxqj.png" />
               <img id="inputActivated" crossOrigin="anonymous" src="http://i.imgur.com/Sls7xlQ.png" />
 

--- a/react-client/src/components/signInUpComponents/signin.jsx
+++ b/react-client/src/components/signInUpComponents/signin.jsx
@@ -33,13 +33,13 @@ export default props => (
 
     {/* Preload (but don't display) the browser cache with UI images so that the follow-up VR scene loads faster */}
     <img alt="lobby-_1" src="http://i.imgur.com/A6fO7Bf.jpg" style={{display: 'none'}} crossOrigin="anonymous"/>
-    <img alt="exit" src="https://s3.amazonaws.com/vrpics/ui-icons/icon-dashboard_512x512.png" style={{display: 'none'}} crossOrigin="anonymous"/>
+    <img alt="exit" src="http://i.imgur.com/5x56Jce.png" style={{display: 'none'}} crossOrigin="anonymous"/>
 
-    <img src="https://s3.amazonaws.com/vrpics/ui-icons/icon-home_512x512.png" style={{display: 'none'}} crossOrigin="anonymous"/>
-    <img src="https://s3.amazonaws.com/vrpics/ui-icons/icon-favorite_512x512.png" style={{display: 'none'}} crossOrigin="anonymous"/>
+    <img alt="home" src="http://i.imgur.com/PMgJxSU.png" style={{display: 'none'}} crossOrigin="anonymous"/>
+    <img alt="like" src="http://i.imgur.com/Iz5kgoH.png" style={{display: 'none'}} crossOrigin="anonymous"/>
     <img alt="liked" src="http://i.imgur.com/XTLYqU3.png" style={{display: 'none'}} crossOrigin="anonymous"/>
-    <img src="https://s3.amazonaws.com/vrpics/ui-icons/icon-mic_512x512.png" style={{display: 'none'}} crossOrigin="anonymous"/>
-    <img src="https://s3.amazonaws.com/vrpics/ui-icons/icon-mic-activated_512x512.png" style={{display: 'none'}} crossOrigin="anonymous"/>
+    <img alt="mic" src="http://i.imgur.com/wNqlh3b.png" style={{display: 'none'}} crossOrigin="anonymous"/>
+    <img alt="micActivated" src="http://i.imgur.com/p433Gsv.png" style={{display: 'none'}} crossOrigin="anonymous"/>
 
     <img alt="input" src="http://i.imgur.com/sELlxqj.png" style={{display: 'none'}} crossOrigin="anonymous"/>
     <img alt="input activated" src="http://i.imgur.com/Sls7xlQ.png" style={{display: 'none'}} crossOrigin="anonymous"/>


### PR DESCRIPTION
It seems like we're getting CORS errors again.

The UI icons (start mic recording, exit to lobby, etc.) that are hosted on the S3 bucket show up as black squares on my iPhone. The Imgur-hosted icons don't have this problem, so I uploaded all the S3-hosted images to Imgur (at the cost of exceeding the "6 simultaneous connections per host" limit that will cause subsequent requests to Imgur to wait for the first 6 connections to finish.